### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.22.0
 logzero>=1.5.0
 beautifulsoup4>=4.8.2
-fuzzywuzzy>=0.18.0
+rapidfuzz>=0.2.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     version='0.0.3',
     packages=['spotifind'],
     url='https://github.com/samapriya/spotifind',
-    install_requires=['requests>=2.21.1','logzero>=1.5.0','beautifulsoup4>=4.8.2','fuzzywuzzy>=0.18.0'],
+    install_requires=['requests>=2.21.1','logzero>=1.5.0','beautifulsoup4>=4.8.2','rapidfuzz>=0.2.2'],
     license='Apache 2.0',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/spotifind/spotifind.py
+++ b/spotifind/spotifind.py
@@ -28,7 +28,7 @@ import base64
 import sys
 import getpass
 import webbrowser
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from logzero import logger
 from os.path import expanduser
 from bs4 import BeautifulSoup


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on an old version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy